### PR TITLE
feat: Add `new-line-at-end-of-file` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,11 @@ ignore: |
 
 ## Implemented Rules
 
-### ✅ Phase 1 (Current)
+### ✅ Phase 1 (Complete)
 
 1. **trailing-spaces** - Detects whitespace at line endings
    - Level: Error
    - No configuration
-
-### 🚧 Phase 1 (In Progress)
 
 2. **line-length** - Enforces maximum line length
    - Level: Error
@@ -173,11 +171,15 @@ ignore: |
    - Level: Error
    - Options: `spaces` (2/4/consistent), `indent-sequences`
 
+7. **new-line-at-end-of-file** - Requires newline at end of file
+   - Level: Error
+   - POSIX standard compliance
+
 ### 📋 Future Rules
 
-Additional 17 rules planned for full yamllint compatibility:
-- truthy, hyphens, comments, new-line-at-end-of-file
-- braces, brackets, commas, empty-lines, new-lines
+Additional 16 rules planned for full yamllint compatibility:
+- truthy, hyphens, comments, empty-lines
+- braces, brackets, commas, new-lines
 - comments-indentation, document-end, empty-values
 - float-values, octal-values, quoted-strings, key-ordering
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -44,6 +44,9 @@ impl Config {
         config
             .rules
             .insert("indentation".to_string(), RuleLevel::Error);
+        config
+            .rules
+            .insert("new-line-at-end-of-file".to_string(), RuleLevel::Error);
 
         config
     }
@@ -71,6 +74,9 @@ impl Config {
         config
             .rules
             .insert("indentation".to_string(), RuleLevel::Warning);
+        config
+            .rules
+            .insert("new-line-at-end-of-file".to_string(), RuleLevel::Warning);
 
         config
     }

--- a/core/src/rules/mod.rs
+++ b/core/src/rules/mod.rs
@@ -8,6 +8,7 @@ pub mod document_start;
 pub mod indentation;
 pub mod key_duplicates;
 pub mod line_length;
+pub mod new_line_at_end_of_file;
 pub mod trailing_spaces;
 
 /// Configuration for a specific rule
@@ -77,6 +78,7 @@ impl RuleRegistry {
         registry.register(Box::new(colons::ColonsRule::new()));
         registry.register(Box::new(key_duplicates::KeyDuplicatesRule));
         registry.register(Box::new(indentation::IndentationRule::new()));
+        registry.register(Box::new(new_line_at_end_of_file::NewLineAtEndOfFileRule));
         registry
     }
 

--- a/core/src/rules/new_line_at_end_of_file.rs
+++ b/core/src/rules/new_line_at_end_of_file.rs
@@ -1,0 +1,132 @@
+//! New line at end of file rule - ensures files end with a newline
+
+use crate::problem::{LintLevel, LintProblem};
+use crate::rules::{LintContext, Rule, RuleLevel};
+
+/// Rule that checks if a file ends with a newline character
+///
+/// This is a POSIX standard requirement for text files and prevents
+/// unnecessary diffs in version control when adding content to file end.
+#[derive(Debug)]
+pub struct NewLineAtEndOfFileRule;
+
+impl Rule for NewLineAtEndOfFileRule {
+    fn name(&self) -> &'static str {
+        "new-line-at-end-of-file"
+    }
+
+    fn check(&self, context: &LintContext) -> Vec<LintProblem> {
+        let mut problems = Vec::new();
+
+        // Empty files are considered valid
+        if context.content.is_empty() {
+            return problems;
+        }
+
+        // Check if content ends with a newline
+        if !context.content.ends_with('\n') {
+            let line_count = context.lines.len();
+            let last_line_len = context.lines.last().map(|l| l.len()).unwrap_or(0);
+
+            problems.push(LintProblem::new(
+                line_count,
+                last_line_len + 1,
+                "no new line character at the end of file",
+                self.name(),
+                LintLevel::Error,
+            ));
+        }
+
+        problems
+    }
+
+    fn default_level(&self) -> RuleLevel {
+        RuleLevel::Error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_with_newline() {
+        let yaml = "key: value\n";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        assert!(problems.is_empty());
+    }
+
+    #[test]
+    fn test_file_without_newline() {
+        let yaml = "key: value";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        assert_eq!(problems.len(), 1);
+        assert_eq!(problems[0].line, 1);
+        assert_eq!(problems[0].column, 11); // After "key: value"
+        assert_eq!(
+            problems[0].message,
+            "no new line character at the end of file"
+        );
+        assert_eq!(problems[0].level, LintLevel::Error);
+    }
+
+    #[test]
+    fn test_multiline_file_without_newline() {
+        let yaml = "key1: value1\nkey2: value2";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        assert_eq!(problems.len(), 1);
+        assert_eq!(problems[0].line, 2);
+        assert_eq!(problems[0].column, 13); // After "key2: value2"
+    }
+
+    #[test]
+    fn test_multiline_file_with_newline() {
+        let yaml = "key1: value1\nkey2: value2\n";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        assert!(problems.is_empty());
+    }
+
+    #[test]
+    fn test_empty_file() {
+        let yaml = "";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        // Empty files are considered valid
+        assert!(problems.is_empty());
+    }
+
+    #[test]
+    fn test_only_newline() {
+        let yaml = "\n";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        assert!(problems.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_trailing_newlines() {
+        let yaml = "key: value\n\n\n";
+        let context = LintContext::new(yaml.to_string());
+        let rule = NewLineAtEndOfFileRule;
+        let problems = rule.check(&context);
+
+        // Multiple trailing newlines are still valid (ends with \n)
+        assert!(problems.is_empty());
+    }
+}

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -185,6 +185,30 @@ list:
   - item3
 ```
 
+### new-line-at-end-of-file
+
+**Level**: Error (default)
+**Configurable**: No
+
+Requires files to end with a newline character.
+
+**Why it matters**: POSIX standard requires text files to end with a newline. This also prevents unnecessary diffs in version control when adding content to file end.
+
+**Examples**:
+
+```yaml
+# Bad - file ends without newline
+key: value
+```
+
+```yaml
+# Good - file ends with newline
+key: value
+⏎
+```
+
+**Note**: Empty files are considered valid.
+
 ## Rule Levels
 
 Each rule can be configured with one of three levels:
@@ -209,6 +233,7 @@ Most rules as warnings:
 - `line-length`: warning
 - `colons`: warning
 - `indentation`: warning
+- `new-line-at-end-of-file`: warning
 - `key-duplicates`: error (kept as error)
 - `document-start`: disabled
 
@@ -226,9 +251,6 @@ Control spacing after list item hyphens.
 
 ### comments
 Enforce comment formatting and spacing.
-
-### new-line-at-end-of-file
-Require a newline at the end of files (POSIX standard).
 
 ### braces / brackets
 Control spacing in flow collections `{}` and `[]`.


### PR DESCRIPTION
## Summary

Add a `new-line-at-end-of-file` rule to enforce POSIX-compliant file endings.

## Changes

- **New Rule**: `NewLineAtEndOfFileRule` in `core/src/rules/new_line_at_end_of_file.rs`
- **Registration**: Added to `RuleRegistry::with_defaults()`
- **Presets**: 
  - Default: `error`
  - Relaxed: `warning`
- **Documentation**: Updated `docs/RULES.md` and `README.md`
- **Tests**: 7 unit tests covering various edge cases

## Behavior

- ✅ Files ending with `\n` pass
- ❌ Files without trailing newline report error
- ✅ Empty files are considered valid
- ✅ Multiple trailing newlines are valid (still ends with `\n`)

## Test Plan

- [x] `make ci` passes (fmt-check, lint, test)
- [x] All 74 tests pass
- [x] New rule tests cover edge cases

Closes #1