### PR TITLE
feat: Add parallel linting support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "1.0"
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
+rayon = "1.10"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Built with [Claude Code](https://www.anthropic.com/claude-code) and [Cursor](htt
 ## Features
 
 - ✅ Fast and efficient YAML linting
+- ✅ **Parallel linting** using all CPU cores (`-j`/`--jobs`)
 - ✅ **Auto-fix** support for common issues (`--fix`)
 - ✅ Multiple output formats (standard, colored, parsable)
 - ✅ Configurable rules with preset configurations
@@ -133,6 +134,19 @@ yaml-lint --dry-run file.yaml
 - `trailing-spaces` - Removes trailing whitespace
 - `new-line-at-end-of-file` - Adds missing newline at end of file
 - `empty-lines` - Removes excess blank lines
+
+### Parallel linting
+
+```bash
+# Auto-detect thread count (default — uses all logical CPUs)
+yaml-lint src/
+
+# Explicit thread count
+yaml-lint -j 4 src/
+
+# Single-threaded (useful for debugging)
+yaml-lint -j 1 src/
+```
 
 ### Options
 
@@ -270,7 +284,7 @@ key: |
 - [x] Phase 1: Core infrastructure + 6 priority rules
 - [ ] Phase 2: Additional output formats, directives, more rules
 - [ ] Phase 3: Full yamllint parity (23 rules)
-- [ ] Phase 4: Performance optimizations, parallel linting
+- [x] Phase 4: Performance optimizations, parallel linting
 - [ ] Phase 5: Editor integration (LSP?)
 
 ## Contributing

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 walkdir = "2.5"
 ignore = "0.4"
 is-terminal = "0.4.17"
+rayon.workspace = true
 
 [dev-dependencies]
 cargo-husky.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
     let lint_results: Vec<(PathBuf, anyhow::Result<Vec<yaml_lint_core::LintProblem>>)> = yaml_files
         .par_iter()
         .map(|file| {
-            let result = linter.lint_file(file).map_err(|e| anyhow::anyhow!("{}", e));
+            let result = linter.lint_file(file).map_err(Into::into);
             (file.clone(), result)
         })
         .collect();
@@ -167,6 +167,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Minimal per-file summary collected from the parallel fix phase.
+struct FixFileSummary {
+    has_fixes: bool,
+    fixes_applied: usize,
+    fix_rule_summary: Vec<String>,
+    has_unfixable: bool,
+}
+
 /// Run in fix mode
 fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()> {
     let registry = config.create_registry();
@@ -174,14 +182,39 @@ fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()
 
     let is_dry_run = cli.dry_run;
 
-    // Process files in parallel, collect results ordered by file path
-    type FixEntry = (PathBuf, anyhow::Result<yaml_lint_core::FixResult>);
+    // Process files in parallel.
+    // Fixed content is written to disk immediately inside the parallel phase so
+    // the full content of every file is never held in memory simultaneously.
+    type FixEntry = (PathBuf, anyhow::Result<FixFileSummary>);
     let fix_results: Vec<FixEntry> = yaml_files
         .par_iter()
         .map(|file| {
-            let result = fs::read_to_string(file)
-                .with_context(|| format!("Failed to read {}", file.display()))
-                .map(|content| fixer.fix(&file.display().to_string(), &content));
+            let result = (|| -> anyhow::Result<FixFileSummary> {
+                let content = fs::read_to_string(file)
+                    .with_context(|| format!("Failed to read {}", file.display()))?;
+                let fix_result = fixer.fix(&file.display().to_string(), &content);
+
+                // Write fixed content immediately to avoid holding all file contents in
+                // memory at once (only in non-dry-run mode).
+                #[allow(clippy::collapsible_if)] // Nested ifs required for MSRV 1.85 compatibility
+                if !is_dry_run {
+                    if let Some(fixed_content) = &fix_result.fixed_content {
+                        fs::write(file, fixed_content)
+                            .with_context(|| format!("Failed to write {}", file.display()))?;
+                    }
+                }
+
+                Ok(FixFileSummary {
+                    has_fixes: fix_result.has_fixes(),
+                    fixes_applied: fix_result.fixes_applied,
+                    fix_rule_summary: fix_result
+                        .fixes_by_rule
+                        .iter()
+                        .map(|(rule, count)| format!("{}: {}", rule, count))
+                        .collect(),
+                    has_unfixable: fix_result.has_unfixable(),
+                })
+            })();
             (file.clone(), result)
         })
         .collect();
@@ -190,42 +223,25 @@ fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()
     let mut files_fixed = 0;
     let mut files_with_unfixable = 0;
 
-    for (file, result) in &fix_results {
-        let fix_result = result
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!("{}", e))
-            .with_context(|| format!("Failed to process {}", file.display()))?;
+    // Print results in deterministic file order
+    for (file, result) in fix_results {
+        let summary = result.with_context(|| format!("Failed to process {}", file.display()))?;
 
-        if fix_result.has_fixes() {
+        if summary.has_fixes {
             files_fixed += 1;
-            total_fixed += fix_result.fixes_applied;
-
-            let fix_summary: Vec<String> = fix_result
-                .fixes_by_rule
-                .iter()
-                .map(|(rule, count)| format!("{}: {}", rule, count))
-                .collect();
+            total_fixed += summary.fixes_applied;
 
             let action = if is_dry_run { "would fix" } else { "fixed" };
             println!(
                 "{}: {} {} issue(s) ({})",
                 file.display(),
                 action,
-                fix_result.fixes_applied,
-                fix_summary.join(", ")
+                summary.fixes_applied,
+                summary.fix_rule_summary.join(", ")
             );
-
-            // Write fixed content (only in non-dry-run mode)
-            #[allow(clippy::collapsible_if)] // Nested ifs required for MSRV 1.85 compatibility
-            if !is_dry_run {
-                if let Some(fixed_content) = &fix_result.fixed_content {
-                    fs::write(file, fixed_content)
-                        .with_context(|| format!("Failed to write {}", file.display()))?;
-                }
-            }
         }
 
-        if fix_result.has_unfixable() {
+        if summary.has_unfixable {
             files_with_unfixable += 1;
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use is_terminal::IsTerminal;
+use rayon::prelude::*;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
@@ -60,6 +61,10 @@ struct Cli {
     /// Show what would be fixed without making changes
     #[arg(long)]
     dry_run: bool,
+
+    /// Number of parallel jobs (0 = auto-detect based on CPU count)
+    #[arg(short = 'j', long, default_value = "0")]
+    jobs: usize,
 }
 
 fn main() -> Result<()> {
@@ -67,6 +72,9 @@ fn main() -> Result<()> {
 
     // Configure color output
     configure_colors(&cli.color);
+
+    // Configure rayon thread pool
+    configure_thread_pool(cli.jobs)?;
 
     // Load configuration
     let config = load_config(&cli)?;
@@ -101,19 +109,28 @@ fn main() -> Result<()> {
 
     let formatter = format.formatter();
 
-    // Lint all files
+    // Lint all files in parallel, collect results ordered by file path
+    let lint_results: Vec<(PathBuf, anyhow::Result<Vec<yaml_lint_core::LintProblem>>)> = yaml_files
+        .par_iter()
+        .map(|file| {
+            let result = linter.lint_file(file).map_err(|e| anyhow::anyhow!("{}", e));
+            (file.clone(), result)
+        })
+        .collect();
+
+    // Output results in deterministic file order
     let mut has_errors = false;
     let mut has_warnings = false;
     let mut total_problems = 0;
 
-    for file in &yaml_files {
-        match linter.lint_file(file) {
+    for (file, result) in &lint_results {
+        match result {
             Ok(problems) => {
                 if !problems.is_empty() {
-                    let output = formatter.format_problems(&problems, &file.display().to_string());
+                    let output = formatter.format_problems(problems, &file.display().to_string());
                     print!("{}", output);
 
-                    for problem in &problems {
+                    for problem in problems {
                         match problem.level {
                             LintLevel::Error => has_errors = true,
                             LintLevel::Warning => has_warnings = true,
@@ -151,29 +168,39 @@ fn main() -> Result<()> {
 }
 
 /// Run in fix mode
-#[allow(clippy::collapsible_if)] // Nested ifs required for MSRV 1.85 compatibility
 fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()> {
     let registry = config.create_registry();
     let fixer = Fixer::new(&registry);
+
+    let is_dry_run = cli.dry_run;
+
+    // Process files in parallel, collect results ordered by file path
+    type FixEntry = (PathBuf, anyhow::Result<yaml_lint_core::FixResult>);
+    let fix_results: Vec<FixEntry> = yaml_files
+        .par_iter()
+        .map(|file| {
+            let result = fs::read_to_string(file)
+                .with_context(|| format!("Failed to read {}", file.display()))
+                .map(|content| fixer.fix(&file.display().to_string(), &content));
+            (file.clone(), result)
+        })
+        .collect();
 
     let mut total_fixed = 0;
     let mut files_fixed = 0;
     let mut files_with_unfixable = 0;
 
-    let is_dry_run = cli.dry_run;
+    for (file, result) in &fix_results {
+        let fix_result = result
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("{}", e))
+            .with_context(|| format!("Failed to process {}", file.display()))?;
 
-    for file in yaml_files {
-        let content = fs::read_to_string(file)
-            .with_context(|| format!("Failed to read {}", file.display()))?;
-
-        let result = fixer.fix(&file.display().to_string(), &content);
-
-        if result.has_fixes() {
+        if fix_result.has_fixes() {
             files_fixed += 1;
-            total_fixed += result.fixes_applied;
+            total_fixed += fix_result.fixes_applied;
 
-            // Format fix summary for this file
-            let fix_summary: Vec<String> = result
+            let fix_summary: Vec<String> = fix_result
                 .fixes_by_rule
                 .iter()
                 .map(|(rule, count)| format!("{}: {}", rule, count))
@@ -184,20 +211,21 @@ fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()
                 "{}: {} {} issue(s) ({})",
                 file.display(),
                 action,
-                result.fixes_applied,
+                fix_result.fixes_applied,
                 fix_summary.join(", ")
             );
 
             // Write fixed content (only in non-dry-run mode)
+            #[allow(clippy::collapsible_if)] // Nested ifs required for MSRV 1.85 compatibility
             if !is_dry_run {
-                if let Some(fixed_content) = &result.fixed_content {
+                if let Some(fixed_content) = &fix_result.fixed_content {
                     fs::write(file, fixed_content)
                         .with_context(|| format!("Failed to write {}", file.display()))?;
                 }
             }
         }
 
-        if result.has_unfixable() {
+        if fix_result.has_unfixable() {
             files_with_unfixable += 1;
         }
     }
@@ -218,6 +246,20 @@ fn run_fix_mode(cli: &Cli, config: &Config, yaml_files: &[PathBuf]) -> Result<()
         std::process::exit(1);
     }
 
+    Ok(())
+}
+
+/// Configure rayon thread pool size
+///
+/// `jobs == 0` means auto-detect (use rayon default, which uses all logical CPUs).
+/// `jobs >= 1` sets an explicit thread count.
+fn configure_thread_pool(jobs: usize) -> Result<()> {
+    if jobs > 0 {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(jobs)
+            .build_global()
+            .context("Failed to configure thread pool")?;
+    }
     Ok(())
 }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -150,6 +150,7 @@ yaml-lint [OPTIONS] <FILES>...
 | `-d, --preset <NAME>` | Use preset (default, relaxed) |
 | `-f, --format <FORMAT>` | Output format (standard, colored, parsable) |
 | `--strict` | Treat warnings as errors (exit code 2) |
+| `-j, --jobs <N>` | Number of parallel jobs (0 = auto-detect, default: 0) |
 | `--list-files` | List files that would be linted |
 | `-h, --help` | Show help |
 | `-V, --version` | Show version |
@@ -171,6 +172,12 @@ yaml-lint --strict file.yaml
 
 # List files without linting
 yaml-lint --list-files src/
+
+# Parallel linting with 4 threads
+yaml-lint -j 4 src/
+
+# Single-threaded (useful for debugging)
+yaml-lint -j 1 src/
 ```
 
 ## Output Formats


### PR DESCRIPTION
## Summary

- Add `rayon`-based parallel file processing for both lint and fix modes
- Add `-j`/`--jobs` CLI flag to control thread count

## Changes

- `Cargo.toml` — add `rayon = "1.10"` to workspace dependencies
- `cli/Cargo.toml` — depend on workspace rayon
- `cli/src/main.rs` — parallel lint loop, parallel fix loop, `configure_thread_pool()`, `--jobs` flag
- `docs/USAGE.md` — document the new flag and examples

## Behaviour

| Flag | Behaviour |
|------|-----------|
| `-j 0` (default) | Auto-detect: rayon uses all logical CPUs |
| `-j N` | Use exactly N threads |
| `-j 1` | Single-threaded (useful for debugging) |

Output order is always deterministic — results are collected in parallel then printed in the original file-collection order.

No core crate changes were needed: `Rule: Send + Sync` was already on the trait, making `Linter` thread-safe.

## Test plan

- [x] `make ci` passes (175 unit tests + 39 integration tests)
- [x] Manual smoke-test with `-j 1`, `-j 4`, `-j 0` produces identical output

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)